### PR TITLE
Update README for SQL validation

### DIFF
--- a/exercises/08.sql/02.problem.validation/README.mdx
+++ b/exercises/08.sql/02.problem.validation/README.mdx
@@ -31,7 +31,7 @@ So what we can do instead, is add runtime validation with
 
 ```tsx
 import { z } from 'zod'
-const ReportSchema = z({
+const ReportSchema = z.object({
 	id: z.string(),
 	name: z.string(),
 	number: z.number(),


### PR DESCRIPTION
I'm only 90% sure about this, but from what I can tell, `z` isn't directly callable. I _think_ this is supposed to be `z.object()`.