### PR TITLE
fix link to "/users" in Identify the problem section

### DIFF
--- a/exercises/09.optimize/02.problem.multi-column-index/README.mdx
+++ b/exercises/09.optimize/02.problem.multi-column-index/README.mdx
@@ -25,7 +25,7 @@ instructions to do some analysis.
 
 ## Identify the problem query
 
-If you run the query by opening <LinkToApp to="/user" />, you should see the
+If you run the query by opening <LinkToApp to="/users" />, you should see the
 query that was executed in the terminal output. It should log something like
 this:
 


### PR DESCRIPTION
The first paragraph of "Identify the problem query" section has a link to "/user" instead of "/users"